### PR TITLE
fix multibyte split at end of buffer

### DIFF
--- a/main.c
+++ b/main.c
@@ -4,7 +4,7 @@
 #include <unistd.h>
 #include "is_utf8.h"
 
-#define BUFSIZE 4096
+#define BUFSIZE 4140 /* 4140 is divisible by 2, 3, 4, 5 and 6 */
 
 int main(int ac, char **av)
 {


### PR DESCRIPTION
As a valid utf-8 sequence only has 6 forms: 1 byte, 2 bytes, ..., 6 bytes, it can avoid the truncation of a valid utf-8 sequence if the BUFSIZE is set to 4140(4140 is divisible by 2, 3, 4, 5 and 6). :-)
