### PR TITLE
added option to get first invalid byte which is suitable for cropping only utf-8 part of string

### DIFF
--- a/is_utf8.c
+++ b/is_utf8.c
@@ -15,13 +15,15 @@
   111110xx 10xxxxxx 10xxxxxx 10xxxxxx 10xxxxxx
   1111110x 10xxxxxx 10xxxxxx 10xxxxxx 10xxxxxx 10xxxxxx
 */
-int is_utf8(unsigned char *str, size_t len)
+int is_utf8(unsigned char *str, size_t len, size_t * first_invalid_pos)
 {
     size_t i = 0;
+    size_t j = 0;
     size_t continuation_bytes = 0;
 
     while (i < len)
     {
+        j = i;
         if (str[i] <= 0x7F)
             continuation_bytes = 0;
         else if (str[i] >= 0xC0 /*11000000*/ && str[i] <= 0xDF /*11011111*/)
@@ -31,7 +33,10 @@ int is_utf8(unsigned char *str, size_t len)
         else if (str[i] >= 0xF0 /*11110000*/ && str[i] <= 0xF4 /* Cause of RFC 3629 */)
             continuation_bytes = 3;
         else
-            return i + 1;
+        {
+            if(first_invalid_pos) *first_invalid_pos = j;
+            return i+1;
+        }
         i += 1;
         while (i < len && continuation_bytes > 0
                && str[i] >= 0x80
@@ -41,7 +46,10 @@ int is_utf8(unsigned char *str, size_t len)
             continuation_bytes -= 1;
         }
         if (continuation_bytes != 0)
-            return i + 1;
+        {
+            if(first_invalid_pos) *first_invalid_pos = j;
+            return i+1;
+        }
     }
     return 0;
 }

--- a/is_utf8.h
+++ b/is_utf8.h
@@ -3,6 +3,6 @@
 
 #include <stdlib.h>
 
-int is_utf8(unsigned char *str, size_t len);
+int is_utf8(unsigned char *str, size_t len, size_t * first_invalid_pos);
 
 #endif /* _IS_UTF8_H */

--- a/main.c
+++ b/main.c
@@ -10,6 +10,7 @@ int main(int ac, char **av)
 {
     char buffer[BUFSIZE];
     int  read_retval;
+    size_t pos;
 
     if (ac != 2)
     {
@@ -28,10 +29,21 @@ int main(int ac, char **av)
                 perror("read");
                 return EXIT_FAILURE;
             }
-            if (is_utf8((unsigned char*)buffer, read_retval) != 0)
+
+            if(is_utf8((unsigned char*)buffer, read_retval, &pos))
+            {
+                buffer[pos] = 0;
+                fprintf(stdout,"%s\n", buffer);
                 return EXIT_FAILURE;
+            }
+            else
+            {
+                fprintf(stdout, "%s\n", buffer);
+            }
+            /*if (is_utf8((unsigned char*)buffer, read_retval) != 0)
+                return EXIT_FAILURE;*/
         }
         return EXIT_SUCCESS;
     }
-    return is_utf8((unsigned char*)av[1], strlen(av[1]));
+    return is_utf8((unsigned char*)av[1], strlen(av[1]), NULL);
 }

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,18 @@
+
+answer=$(echo Привет$(echo мир | iconv -f utf-8 -t koi8-r) | ./is_utf8 -)
+error_level=$?
+[ $error_level == 1 ] || exit 1
+[ $answer == "Привет" ] || exit 1
+
+answer=$(echo Привет$(echo мир | iconv -f utf-8 -t cp1251) | ./is_utf8 -)
+error_level=$?
+[ $error_level == 1 ] || exit 1
+[ $answer == "Привет" ] || exit 1
+
+answer=$(echo Привет$(echo мир | iconv -f utf-8 -t utf-8) | ./is_utf8 -)
+error_level=$?
+[ $error_level == 0 ] || exit 1
+[ $answer == "Приветмир" ] || exit 1
+
+echo "All tests are OK"
+exit 0


### PR DESCRIPTION
Sometimes it's usable to crop unicode string and leave only valid part. For example, I'm using this in my android application.

I've modified Your code and now it provides this functionality. It still WILL return non-zero when it fails and zero when it all OK, but when You specify a valid pointer as fisrt_invalid_pos, a first position of invalid byte will be written. 
